### PR TITLE
Improve getter/setter code

### DIFF
--- a/modelTests.html
+++ b/modelTests.html
@@ -27,6 +27,9 @@
 		test('data object is populated', window.model.data.stuff.info[1], 2);
 		test('non-nested getting', window.model.get('name'), 'dave');
 		test('dot syntax getting', window.model.get('stuff.info.1'), 2);
+		test('square bracket getting', window.model.get('stuff.info[1]'), 2);
+		test('array based getting', window.model.get(['stuff', 'info', 1]), 2);
+		test('mixed syntax getting', window.model.get('stuff.nest[0].foo'), 'bar');
 		test('non-existent fallback response', window.model.get('stuff.info.6'), null);
 		// Fallback
 		test('custom fallback response', window.model.get('stuff.info.6', 'hello'), 'hello');

--- a/modelTests.html
+++ b/modelTests.html
@@ -9,7 +9,8 @@
 			{
 				'stuff': {
 					'northwind': 'contoso',
-					'info': [1,2,3]
+					'info': [1,2,3],
+					'nest': [{ 'foo': 'bar' }]
 				},
 				'name': 'dave'
 			}
@@ -45,6 +46,12 @@
 		test('setting and getting new arrays', window.model.data.new.object.arr[0], 1);
 		window.model.set('new.object.arr2.0', 'hi');
 		test('setting and getting numerical properties', window.model.data.new.object.arr2[0], 'hi');
+
+		window.model.set('new.object.arr2[0]', 'hey');
+		console.assert(window.model.data.new.object.arr2[0] === 'hey');
+
+		window.model.set(['new', 'object', 'arr2', '0'], 'hello');
+		console.assert(window.model.data.new.object.arr2[0] === 'hello');
 
 		// test read events
 		let answers1 = [

--- a/src/model.js
+++ b/src/model.js
@@ -57,7 +57,7 @@ const Model = function(_data) {
 const jsPathRegex = /([^[.\]])+/g;
 
 // get attribute
-Model.prototype.get = function(key, fallback = null)
+Model.prototype.get = function(key, fallback = undefined)
 {
     if (!key) return fallback;
 

--- a/src/model.js
+++ b/src/model.js
@@ -73,7 +73,7 @@ Model.prototype.set = function(key, value)
     const keyArray = Array.isArray(key) ? key : key.match(jsPathRegex);
 
     keyArray.reduce((acc, prop, i) => {
-        if (acc[prop] === undefined) acc[prop] = {}
+        if (acc[prop] === undefined) acc[prop] = {};
         if (i === keyArray.length - 1) acc[prop] = value;
         return acc[prop];
     }, this.data);


### PR DESCRIPTION
Improved get/set code taken from [You Might Not Need Lodash](https://youmightnotneed.com/lodash/) ([get](https://github.com/cedmax/youmightnotneed/blob/production/src/content/lodash/object/get/vanilla.js), [set](https://github.com/cedmax/youmightnotneed/blob/production/src/content/lodash/object/set/vanilla.js))

This also allows support for bracket notation, such as `path.to.array[0].some.nested.item` and array based paths like `['path', 'to', 'array', 0, 'some', 'nested', 'item']`