### PR TITLE
Reactive template

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -1,0 +1,71 @@
+var toString36 = (num) => num.toString(36).substr(2);
+
+var getUid = () => toString36(Math.random()) + toString36(Date.now());
+
+const Template = function(markupFragments, modelProps) {
+    this.markupFragments = markupFragments;
+    this.modelProps = modelProps;
+    this.propNodeMap = {};
+    this.uid = getUid();
+    this.el = document.createElement('span');
+    this.el.setAttribute(`data-el-${this.uid}`, '');
+    this.el.innerHTML = markupFragments.join(`<span data-el-${this.uid}-placeholder></span>`);
+    const placeholders = this.el.querySelectorAll(`[data-el-${this.uid}-placeholder]`);
+    this.modelProps.forEach((prop, ind) => {
+        const placeholder = placeholders[ind];
+        const textNode = document.createTextNode('');
+        placeholder.parentNode.insertBefore(textNode, placeholder);
+        placeholder.parentNode.removeChild(placeholder);
+        (this.propNodeMap[prop] = this.propNodeMap[prop] || []).push(textNode);
+    });
+};
+
+Template.prototype.bind = function(model) {
+    model.on('change', (type, namespace, updated) => {
+        if (namespace in this.propNodeMap) {
+            for (let node of this.propNodeMap[namespace]) {
+                node.data = updated;
+            }
+        }
+    });
+    for (let [prop, nodes] of Object.entries(this.propNodeMap)) {
+        for (let node of nodes) {
+            node.data = model.get(prop);
+        }
+    }
+    return this;
+}
+
+// TODO: appendTo, insertBefore, insertAfter
+// TODO: Something to handle arrays (and objects)
+
+const createTemplate = (markupFragments, ...modelProps) => new Template(markupFragments, modelProps);
+
+/**
+ * Use like:
+ *
+ * const model = new Model({ name: { first: 'Foo', last: 'Bar' }, item: 'bar' });
+ *
+ * const NameBadge = createTemplate`<div class="namebadge">
+ * Hello, my name is ${'name.first'} ${'name.last'}
+ * </div>
+ * <span>${'name.first'} has a ${'item'}</span>`.bind(model);
+ *
+ * document.body.appendChild(NameBadge.el);
+ *
+ * Will render:
+ * Hello, my name is Foo Bar
+ * Foo has a bar
+ *
+ * When:
+ * model.data.name.first = 'Baz';
+ *
+ * Output will change automatically:
+ * Hello, my name is Baz Bar;
+ * Baz has a bar
+ */
+
+export {
+    Template,
+    createTemplate,
+};


### PR DESCRIPTION
This adds the concept of a reactive template. Templates objects can be created using a helper method provided and template literals, where currently all interpolated values are treated as model data paths. Templates can then be bound to a model object and changes to the model will be reflected in the DOM element. Text nodes are used to ensure only necessary updates to the DOM are made.

Feel free to close, this may muddy things too much and you may prefer the current full render logic.

#### Example

```js
import Model from 'lump/src/model';
import { createTemplate } from 'lump/src/template';

const model = new Model({ name: { first: 'Foo', last: 'Bar' }, item: 'bar' });
 
const NameBadge = createTemplate`<div class="namebadge">
    Hello, my name is ${'name.first'} ${'name.last'}
</div>
<span>${'name.first'} has a ${'item'}</span>`.bind(model);

document.body.appendChild(NameBadge.el);
```

Will render:

> Hello, my name is Foo Bar
> Foo has a bar

If `model.data.name.first = 'baz'` is called, the element will now render:

> Hello, my name is Baz Bar;
> Baz has a bar

[Live example](https://plnkr.co/edit/GDhPiQ2ya9cnmcF4)

## To do

- [ ] Improve element attachment ergonomics
- [ ] Cater for array and object data sanely if possible
- [ ] Decide whether to cater for non-text node things like setting data as a class, attribute or tag (probably not?)