### PR TITLE
Make objects so they can never detach

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumpjs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple component and reactive model library",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",

--- a/src/component.js
+++ b/src/component.js
@@ -196,11 +196,11 @@ const Component = function() {
      * @param  {[type]} model     [description]
      * @param  {String} namespace [description]
      */
-    ComponentImplementation.prototype.listenTo = function(model, namespace = '') {
-        if (typeof model.addListener !== 'function') {
+    ComponentImplementation.prototype.subscribeTo = function(model, namespace = '') {
+        if (typeof model.subscribe !== 'function') {
             throw new Error('Model does not support listeners');
         }
-        model.addListener(this, namespace);
+        model.subscribe(this, namespace);
     };
 
     /**

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -31,6 +31,10 @@ describe('Test basic get functionalty', () => {
     test('data object array is populated', () => {
         expect(testModel.data.stuff.info[1]).toBe(2);
     });
+    test('Get root data', () => {
+        expect(testModel.get()).toBe(testModel.data);
+        expect(testModel.get('')).toBe(testModel.data);
+    });
     test('non-nested getting', () => {
         expect(testModel.get('name')).toBe('dave');
     });
@@ -55,6 +59,9 @@ describe('Test basic get functionalty', () => {
     test('Get allows access to values with protected names', () => {
         testModel.data.get = 'test';
         expect(testModel.get('get')).toBe('test');
+    });
+    test('Get something that doesnt exist', () => {
+        expect(testModel.get('bacon.egg.sausage')).toBe(undefined);
     });
 });
 
@@ -492,10 +499,10 @@ describe('Context events', () => {
     test('Get context', () => {
         testModel.set('test.testing.1', {'name': 'bobbert'});
         const testing = testModel.get('test.testing.1');
-        expect(testing.context()).toBe('test.testing.1');
+        expect(testing.getContext()).toBe('test.testing.1');
     });
 
-    test('Can refresh', () => {
+    test('Ensure orphaned object, still shows latest from datapath', () => {
         testModel.set('test', {'data': {name: 'abc'}});
 
         // When using a local obj, complete refresh of object can lead to it becoming
@@ -504,9 +511,45 @@ describe('Context events', () => {
 
         testModel.set('test', {'data': {name: 'def'}});
 
-        expect(data.name).toBe('abc');
-        data = data.refresh();
         expect(data.name).toBe('def');
+    });
+
+    test('Ensure orphaned object handles no longer existing in datapath', () => {
+        testModel.set('test', {'data': {name: 'abc'}});
+
+        // When using a local obj, complete refresh of object can lead to it becoming
+        // orphaned. Refresh model allows it to figure out its real version again.
+        let data = testModel.get('test.data');
+
+        testModel.set('test', {});
+
+        expect(data.name).toBe(undefined);
+    });
+
+     test('Ensure orphaned object can set values correctly', () => {
+        testModel.set('test', {'data': {name: 'abc'}});
+
+        // When using a local obj, complete refresh of object can lead to it becoming
+        // orphaned. Refresh model allows it to figure out its real version again.
+        let data = testModel.get('test.data');
+        testModel.set('test', {'data': {name: 'def'}});
+
+        data.set('name', 'huh');
+
+        expect(testModel.get('test.data.name')).toBe('huh');
+    });
+
+    test('Ensure orphaned object can set values correctly', () => {
+        testModel.set('test', {'data': {name: 'abc'}});
+
+        // When using a local obj, complete refresh of object can lead to it becoming
+        // orphaned. Refresh model allows it to figure out its real version again.
+        let data = testModel.get('test.data');
+        testModel.set('test', {'data': {name: 'def'}});
+
+        data.name = 'hmm';
+
+        expect(testModel.get('test.data.name')).toBe('hmm');
     });
 
     test('Listener objects use proxy data not real data', () => {
@@ -516,7 +559,7 @@ describe('Context events', () => {
 
         testing.on('update', (updated) => {
             count++;
-            expect(updated.context()).toBe('test.testing');
+            expect(updated.getContext()).toBe('test.testing');
         });
 
         testModel.set('test.testing', {'name': 'ziggy'});

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -32,8 +32,8 @@ describe('Test basic get functionalty', () => {
         expect(testModel.data.stuff.info[1]).toBe(2);
     });
     test('Get root data', () => {
-        expect(testModel.get()).toBe(testModel.data);
-        expect(testModel.get('')).toBe(testModel.data);
+        expect(testModel.get().name).toBe('dave');
+        expect(testModel.get('').name).toBe('dave');
     });
     test('non-nested getting', () => {
         expect(testModel.get('name')).toBe('dave');
@@ -507,7 +507,7 @@ describe('Context events', () => {
 
         // When using a local obj, complete refresh of object can lead to it becoming
         // orphaned. Refresh model allows it to figure out its real version again.
-        let data = testModel.get('test.data');
+        const data = testModel.get('test.data');
 
         testModel.set('test', {'data': {name: 'def'}});
 
@@ -519,19 +519,19 @@ describe('Context events', () => {
 
         // When using a local obj, complete refresh of object can lead to it becoming
         // orphaned. Refresh model allows it to figure out its real version again.
-        let data = testModel.get('test.data');
+        const data = testModel.get('test.data');
 
         testModel.set('test', {});
 
         expect(data.name).toBe(undefined);
     });
 
-     test('Ensure orphaned object can set values correctly', () => {
+    test('Ensure orphaned object can set values correctly', () => {
         testModel.set('test', {'data': {name: 'abc'}});
 
         // When using a local obj, complete refresh of object can lead to it becoming
         // orphaned. Refresh model allows it to figure out its real version again.
-        let data = testModel.get('test.data');
+        const data = testModel.get('test.data');
         testModel.set('test', {'data': {name: 'def'}});
 
         data.set('name', 'huh');
@@ -544,7 +544,7 @@ describe('Context events', () => {
 
         // When using a local obj, complete refresh of object can lead to it becoming
         // orphaned. Refresh model allows it to figure out its real version again.
-        let data = testModel.get('test.data');
+        const data = testModel.get('test.data');
         testModel.set('test', {'data': {name: 'def'}});
 
         data.name = 'hmm';


### PR DESCRIPTION
Ensure orphaned objects don't leave old data behind.
Lump model functions now return accessor proxies, which mirror called functions to the underlying dataproxy. This means complete object replacement will no longer orphan references from apps keeping them.

* retire `refresh` as no longer necessary